### PR TITLE
Update ConfParser.jl

### DIFF
--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -17,7 +17,7 @@ type ConfParse
         end
 
         _filename = filename
-        _fh = _open_fh(filename, "r") # _fh was defined inside if-statement: so if syntax!="", then _fh is not defined
+        _fh = open_fh(filename, "r") # _fh was defined inside if-statement: so if syntax!="", then _fh is not defined
         if (isempty(syntax))
             _syntax = guess_syntax(_fh)
         else

--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -17,8 +17,8 @@ type ConfParse
         end
 
         _filename = filename
+        _fh = _open_fh(filename, "r") # _fh was defined inside if-statement: so if syntax!="", then _fh is not defined
         if (isempty(syntax))
-            _fh = open_fh(filename, "r")
             _syntax = guess_syntax(_fh)
         else
             if ((syntax != "ini")  &&
@@ -115,6 +115,8 @@ function parse_conf!(s::ConfParse)
     else
         error("unknown configuration syntax: $(s._syntax)")
     end
+    
+    close(s._fh)                # no need to keep file opened
 end # function parse_conf
 
 #----------
@@ -324,6 +326,7 @@ function save!(s::ConfParse, filename::Any = nothing)
     end
     
     write(s._fh, content)
+    close(s._fh)                # if not closed, content is written when julia-session finishes
 end # function save
 
 #----------


### PR DESCRIPTION
[+] In function ConfParse(filename, syntax =""):
     _fh = _open_fh(filename, "r") moved outside if-statement because if sytax != "", then _fh will be not defined.

[+] In function parse_conf!(s):
     Added close(s._fh), because _fh is not needed anymore for reading

[+] In function save!(s,filename):
     Added close(s._fh). If not closed, filename appears as empty until the julia-session finishes.